### PR TITLE
Add advice regarding preloading audio

### DIFF
--- a/app-developers/audio-files.md
+++ b/app-developers/audio-files.md
@@ -10,6 +10,8 @@ While a podcaster publishes an RSS feed to be reproduced inside your app to help
 
 * **Ensure you never cache audio files in your system** - a podcaster relies on the statistics from their podcast host, and may deliver specific versions to listeners. As one example, NPR produces a [localised afternoon news podcast](https://podnews.net/update/daily-localised-podcast) which uses geo-location of the listener, based on their IP address, to deliver local news stories. Advertising may also be geo-targeted. Of course, locally cache a file on the user's device: but don't take one copy of the audio file and store it in your own systems for user delivery.
 
+* **Ensure you’re not downloading the audio more often than necessary** - a podcaster uses download numbers as a performance metric, so avoid distorting these figures by requesting the audio more than is needed. For browser-based players, set the `audio` element’s `preload` attribute to `none` (not `metadata`, `auto`, or blank). Alternatively, cache the audio locally on the users device.
+
 * **Ensure you call a bot for what it is**. If your app takes a copy of the audio for analysis purposes, please clearly mark that in the user agent. Podnews's bot uses a useragent like `PodnewsBot/1.0 +https://podnews.net/bot` which is clear that this is not a human listen and should not be categorised as one.
 
 Most audio files will be in either MP3 format or AAC-HE format; and podcast loudness should be set between -16 and -14 LUFS.


### PR DESCRIPTION
Further to the discussion on podcastindex.social regarding preloading audio, I'd thought it'd be useful to mention `preload=none` and the reasons for it.

As an aside, serving audio content from a cache via a service worker is a little complex due to range requests (see: https://developer.chrome.com/docs/workbox/serving-cached-audio-and-video). I considered linking to this, but thought it was out-of-scope. Happy to add a link if you think otherwise.

---

Finally, thanks for the podinfra resource. It's been a really useful reference.